### PR TITLE
enhance translation variants styling

### DIFF
--- a/DarkMain.user.css
+++ b/DarkMain.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         Google Translate Dark
 @namespace    Factral
-@version      1.3.5
+@version      1.3.6
 @description  Translate Google Dark Theme
 @author       Factral
 @homepageURL  https://github.com/Factral/GoogleTranslateDarkTheme/
@@ -16,7 +16,8 @@
     .ydsGXd * { color: white; }
     .GAyS9e { all: unset !important; }
     .hX7wnb, .Bljmlb, .qt6jm { border-top-color: #131719 !important; }
-    .U8K5nb { background-color: #bdbdbd !important; }
+    .U8K5nb { background-color: #363636 !important; color: #e6e6e6; }
+    .jq25U {color: #bbb9b9;}
 
     /*backgrounds*/
     .jTj8gd.XzOhkf .a2Icud,#gb,.gb_qa .gb_Kd.gb_Sd.gb_Td,.RvYhPd.Q5Onnd, .RvYhPd.dtohSe,.RvYhPd::before,body, .frame, .ita-hwt-jfk-standard, .history-top-header .history-top-bar,.history-container .info-bar, .phrasebook-top-header, .phrasebook-container .nav-bar, .gb_fd .gb_F, .gb_3d,.RvYhPd,.MmZJl,.aCQag,.ccvoYb,.WFnNle,.I87fLc.XzOhkf,.ySES5, .myVd4c .ySES5,.yFQBKb,.kXN2zb, .zklE3, .BXabBd, .c5bTNd{


### PR DESCRIPTION
Improved translation variants, to be more consistent with dark theme

<img width="955" height="384" alt="изображение" src="https://github.com/user-attachments/assets/6ba122a2-7d8e-48c6-b01e-80137222a04b" />
